### PR TITLE
1.4.3 Crash Fix

### DIFF
--- a/EquipBestItem/ViewModels/MainViewModel.cs
+++ b/EquipBestItem/ViewModels/MainViewModel.cs
@@ -228,7 +228,7 @@ namespace EquipBestItem
 
         public MainViewModel()
         {
-            _inventoryLogic = InventoryManager.MyInventoryLogic;
+            _inventoryLogic = InventoryManager.InventoryLogic;
             _inventory = InventoryBehavior.Inventory;
         }
 


### PR DESCRIPTION
Since Bannerlord has been updated on the main version to 1.4.3, this fix should solve the crash problem due to a invocation call. #6 